### PR TITLE
add proxy

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server"
+import type { NextRequest } from "next/server"
+import { getToken } from "next-auth/jwt"
+
+export async function proxy(request: NextRequest) {
+  const isProtectedRoute = request.nextUrl.pathname.startsWith("/recipe/")
+
+  if (isProtectedRoute) {
+    const token = await getToken({ req: request })
+
+    if (!token) {
+      return NextResponse.redirect(new URL("/recipe", request.url))
+    }
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+}


### PR DESCRIPTION
## Description

Add Next.js proxy middleware for route protection. Protected routes under `/recipe/**` require authentication, while `/recipe` remains accessible as the sign-in entrance.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue

Closes #25 

## Changes Made

- Created `proxy.ts` (Next.js new convention replacing `middleware.ts`)
- Added authentication check using `getToken` from next-auth/jwt
- Protected routes: `/recipe/**` - redirects to `/recipe` if no session
- Unprotected: `/recipe` - accessible for sign-in flow
- Configured matcher to exclude static assets (`_next/static`, `_next/image`, `favicon.ico`)

## Route Protection Logic

```typescript
const isProtectedRoute = request.nextUrl.pathname.startsWith("/recipe/")

if (isProtectedRoute && !token) {
  redirect to /recipe
}
```

## Testing

- [x] Tested locally
- [ ] All tests pass
- [x] No console errors

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Commented code where needed
- [ ] Updated documentation if needed