### PR TITLE
Add Open Graph and Twitter metadata to recipe page

### DIFF
--- a/app/recipe/detail/[recipeId]/page.tsx
+++ b/app/recipe/detail/[recipeId]/page.tsx
@@ -16,9 +16,31 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { recipeId } = await params
   const recipeMetadata = await fetchRecipeMetadata(recipeId)
+
+  const title = `${recipeMetadata.name} | Kenji Wilkins`
+  const description = `Recipe for ${recipeMetadata.name}. Tags: ${recipeMetadata.tags.join(", ")}`
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+  const url = `${baseUrl}/recipe/detail/${recipeId}`
   return {
-    title: `${recipeMetadata.name} | Kenji Wilkins`,
-    description: `Recipe for ${recipeMetadata.name}. Tags: ${recipeMetadata.tags.join(", ")}`,
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: "Kenji Wilkins",
+      locale: "en_US",
+      type: "article",
+      publishedTime: new Date().toISOString(),
+      authors: ["Kenji Wilkins"],
+      tags: recipeMetadata.tags,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      creator: "@kenjiwilkins",
+    },
   }
 }
 


### PR DESCRIPTION
Enhanced the recipe detail page metadata by including Open Graph and Twitter card properties for better social sharing and SEO. Metadata now includes title, description, URL, site name, locale, type, published time, authors, tags, and Twitter creator.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issue

Closes #42 

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

- [ ] Tested locally
- [ ] All tests pass
- [ ] No console errors

## Screenshots

If applicable, add screenshots of the changes.

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Commented code where needed
- [ ] Updated documentation if needed
